### PR TITLE
Run copyTo and remove methods in a background thread

### DIFF
--- a/src/android/IonicCordovaCommon.java
+++ b/src/android/IonicCordovaCommon.java
@@ -95,10 +95,16 @@ public class IonicCordovaCommon extends CordovaPlugin {
     } else if (action.equals("configure")){
       this.configure(callbackContext, args.getJSONObject(0));
     } else if (action.equals("copyTo")){
-      this.copyTo(callbackContext, args.getJSONObject(0));
-    } else if (action.equals("remove")){
-      this.remove(callbackContext, args.getJSONObject(0));
-    } else if (action.equals("downloadFile")){
+      threadhelper( new FileOp( ){
+        public void run(final JSONArray passedArgs, final CallbackContext cbcontext) throws JSONException {
+          copyTo(cbcontext, args.getJSONObject(0));
+        }
+      }, args, callbackContext);    } else if (action.equals("remove")){
+      threadhelper( new FileOp( ){
+        public void run(final JSONArray passedArgs, final CallbackContext cbcontext) throws JSONException {
+          remove(cbcontext, args.getJSONObject(0));
+        }
+      }, args, callbackContext);    } else if (action.equals("downloadFile")){
       threadhelper( new FileOp( ){
         public void run(final JSONArray passedArgs, final CallbackContext cbcontext) throws JSONException {
           downloadFile(cbcontext, passedArgs.getJSONObject(0));


### PR DESCRIPTION
### Issue description
Due to many issues reported that the application hangs during fetching live update, by running the app on a low-end device [HUWAIE-GR5](https://www.gadgetsnow.com/mobile-phones/Huawei-GR5-2017-32GB) found that the `copyTo` method blocks the main UI thread for 128 seconds, by checking the implementation found that the method runs on the foreground not in a background thread. So, in a result the skip button is not enabled after exactly 30 seconds and the user screen just hangs.

### Solution
The solution was to run the `copyTo` and `remove` methods in a background thread to avoid blocking the main UI thread and the user can skip live update if it takes more than 30 seconds

<img width="1364" alt="Screenshot 2022-09-08 at 2 43 19 AM" src="https://user-images.githubusercontent.com/38646828/189010271-6ac1b662-8a63-45e3-b052-81d397ff0ce7.png">

### Note
before merging this PR, I should make it clear on some low-end devices the live update most probably it will always take more than 30 seconds so are we sure that it's okay to allow the user to skip the update after 30 seconds have passed as this will always be the case

### Before and after videos
In the after video you can see that the skip button is enabled after exactly 30 seconds as the UI thread is not blocked
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/38646828/189009667-ccaa2143-0b4e-4fd2-9433-d5f2aadb8330.mp4)  |  ![](https://user-images.githubusercontent.com/38646828/189009700-edf10b61-340f-4ab2-b81b-e2cecfe71f05.mp4)



